### PR TITLE
Fix spelling issue in `RegisterAppInterface` response `hmiCapabilities` description

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4340,7 +4340,7 @@
         </param>
         
         <param name="hmiCapabilities" type="HMICapabilities" mandatory="false" since="3.0">
-            <description>Specifies the HMI capabilities. See HMICapabilities.</description>
+            <description>Specifies the HMI's capabilities. See HMICapabilities.</description>
         </param>
         
         <param name="sdlVersion" type="String" maxlength="100" mandatory="false" platform="documentation" since="3.0">

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4340,7 +4340,7 @@
         </param>
         
         <param name="hmiCapabilities" type="HMICapabilities" mandatory="false" since="3.0">
-            <description>Specifies the HMIÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢s capabilities. See HMICapabilities.</description>
+            <description>Specifies the HMI capabilities. See HMICapabilities.</description>
         </param>
         
         <param name="sdlVersion" type="String" maxlength="100" mandatory="false" platform="documentation" since="3.0">


### PR DESCRIPTION
Removed broken characters from `RegisterAppInterface` response `hmiCapabilities` description, resolving issue #177 