### PR TITLE
ChangeRegistration can respond with result = UNSUPPORTED_RESOURCE

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -6858,6 +6858,7 @@
             <element name="GENERIC_ERROR"/>
             <element name="REJECTED"/>
             <element name="DISALLOWED"/>
+            <element name="UNSUPPORTED_RESOURCE"/>
         </param>
         
         <param name="info" type="String" maxlength="1000" mandatory="false" platform="documentation">


### PR DESCRIPTION
Fixes core issue #1694

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
The ChangeRegistration Response in the MOBILE_API lists a few different possible resultCodes that can be returned but does not list UNSUPPORTED_RESOURCE as one even though this can be returned. (by sending an unsupported ttsName for example)

### Changelog
##### Enhancements
* Makes it more clear to developers that UNSUPPORTED_RESOURCE can be returned from ChangeRegistration

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
