### PR TITLE
Fixed incorrect system capability descriptions

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4417,16 +4417,16 @@
             <description>Used as a descriptor of what data to expect in this struct. The corresponding param to this enum should be included and the only other param included.</description>
         </param>
         <param name="navigationCapability" type="NavigationCapability" mandatory="false">
-            <description>Describes extended capabilities for onboard navigation system </description>
+            <description>Describes extended capabilities for onboard navigation system</description>
         </param>
         <param name="phoneCapability" type="PhoneCapability" mandatory="false">
             <description>Describes extended capabilities of the module's phone feature</description>
         </param>
         <param name="videoStreamingCapability" type="VideoStreamingCapability" mandatory="false">
-            <description>Describes extended capabilities of the module's phone feature</description>
+            <description>Contains information about this system's video streaming capabilities</description>
         </param>
         <param name="remoteControlCapability" type="RemoteControlCapabilities" mandatory="false">
-            <description>Describes extended capabilities of the module's phone feature</description>
+            <description>Contains information about the module's remote control feature</description>
         </param>
         <param name="appServicesCapabilities" type="AppServicesCapabilities" mandatory="false" since="5.1">
             <description>An array of currently available services. If this is an update to the capability the affected services will include an update reason in that item</description>

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4423,7 +4423,7 @@
             <description>Describes extended capabilities of the module's phone feature</description>
         </param>
         <param name="videoStreamingCapability" type="VideoStreamingCapability" mandatory="false">
-            <description>Contains information about this system's video streaming capabilities</description>
+            <description>Contains information about the module's video streaming capabilities</description>
         </param>
         <param name="remoteControlCapability" type="RemoteControlCapabilities" mandatory="false">
             <description>Contains information about the module's remote control feature</description>

--- a/README.md
+++ b/README.md
@@ -3105,10 +3105,10 @@ The systemCapabilityType identifies which data object exists in this struct. For
 | Value |  Type | Mandatory | Description | 
 | ---------- | ---------- |:-----------: |:-----------:|
 |`systemCapabilityType`|SystemCapabilityType|True|Used as a descriptor of what data to expect in this struct. The corresponding param to this enum should be included and the only other param included.|
-|`navigationCapability`|NavigationCapability|False|Describes extended capabilities for onboard navigation system |
+|`navigationCapability`|NavigationCapability|False|Describes extended capabilities for onboard navigation system|
 |`phoneCapability`|PhoneCapability|False|Describes extended capabilities of the module's phone feature|
-|`videoStreamingCapability`|VideoStreamingCapability|False|Describes extended capabilities of the module's phone feature|
-|`remoteControlCapability`|RemoteControlCapabilities|False|Describes extended capabilities of the module's phone feature|
+|`videoStreamingCapability`|VideoStreamingCapability|False|Contains information about this system's video streaming capabilities|
+|`remoteControlCapability`|RemoteControlCapabilities|False|Contains information about the module's remote control feature|
 |`appServicesCapabilities`|AppServicesCapabilities|False|An array of currently available services. If this is an update to the capability the affected services will include an update reason in that item|
 |`seatLocationCapability`|SeatLocationCapability|False|Contains information about the locations of each seat|
 |`displayCapabilities`|DisplayCapability[]|False||

--- a/README.md
+++ b/README.md
@@ -3107,7 +3107,7 @@ The systemCapabilityType identifies which data object exists in this struct. For
 |`systemCapabilityType`|SystemCapabilityType|True|Used as a descriptor of what data to expect in this struct. The corresponding param to this enum should be included and the only other param included.|
 |`navigationCapability`|NavigationCapability|False|Describes extended capabilities for onboard navigation system|
 |`phoneCapability`|PhoneCapability|False|Describes extended capabilities of the module's phone feature|
-|`videoStreamingCapability`|VideoStreamingCapability|False|Contains information about this system's video streaming capabilities|
+|`videoStreamingCapability`|VideoStreamingCapability|False|Contains information about the module's video streaming capabilities|
 |`remoteControlCapability`|RemoteControlCapabilities|False|Contains information about the module's remote control feature|
 |`appServicesCapabilities`|AppServicesCapabilities|False|An array of currently available services. If this is an update to the capability the affected services will include an update reason in that item|
 |`seatLocationCapability`|SeatLocationCapability|False|Contains information about the locations of each seat|


### PR DESCRIPTION
Fixes #228 

Fixed the descriptions for `videoStreamingCapability` and `remoteControlCapability` in the System Capability table.