### PR TITLE
RPC Spec implementation of feature - 0261 New vehicle data WindowStatus

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/xml" href="protocol2html.xsl"?>
 
-<interface name="SmartDeviceLink RAPI" version="6.0.0" minVersion="1.0" date="2019-03-19">
+<interface name="SmartDeviceLink RAPI" version="6.2.0" minVersion="1.0" date="2019-03-19">
     <enum name="Result" internal_scope="base" since="1.0">
         <element name="SUCCESS">
             <description>The request succeeded</description>

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -6466,7 +6466,7 @@
         <param name="myKey" type="MyKey" mandatory="false">
             <description>Information related to the MyKey feature</description>
         </param>
-        <param name="windowStatus" type="WindowStatus" array="true" minsize="0" maxsize="100" mandatory="false">
+        <param name="windowStatus" type="WindowStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="6.2">
             <description>See WindowStatus</description>
         </param>
     </function>
@@ -8167,7 +8167,7 @@
         <param name="myKey" type="MyKey" mandatory="false">
             <description>Information related to the MyKey feature</description>
         </param>
-        <param name="windowStatus" type="WindowStatus" array="true" minsize="0" maxsize="100" mandatory="false">
+        <param name="windowStatus" type="WindowStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="6.2">
             <description>See WindowStatus</description>
         </param>
     </function>

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -569,6 +569,7 @@
         <element name="VEHICLEDATA_ELECTRONICPARKBRAKESTATUS" since="5.0" />
         <element name="VEHICLEDATA_CLOUDAPPVEHICLEID" since="5.1"/>
         <element name="VEHICLEDATA_OEM_CUSTOM_DATA" since="6.0"/>
+        <element name="VEHICLEDATA_WINDOWSTATUS" since="6.2"/>
     </enum>
 
     <enum name="HybridAppPreference" since="5.1">
@@ -2294,6 +2295,21 @@
         </param>
         <param name="levelspan" type="Integer" mandatory="false" defvalue="1" minvalue="1" maxvalue="100">
         </param>
+    </struct>
+
+    <struct name="WindowState" since="6.2">
+      <param name="approximatePosition" type="Integer" minvalue="0" maxvalue="100" mandatory="true">
+        <description>The approximate percentage that the window is open - 0 being fully closed, 100 being fully open</description>
+      </param>
+      <param name="deviation" type="Integer" minvalue="0" maxvalue="100" mandatory="true">
+        <description>The percentage deviation of the approximatePosition. e.g. If the approximatePosition is 50 and the deviation is 10, then the window's location is somewhere between 40 and 60.</description>
+      </param>
+    </struct>
+
+    <struct name="WindowStatus" since="6.2">
+      <description>Describes the status of a window of a door/liftgate etc.</description>
+      <param name="location" type="Grid" mandatory="true"/>
+      <param name="state" type="WindowState" mandatory="true"/>     
     </struct>
 
     <struct name="ModuleInfo" since="6.0">
@@ -5907,6 +5923,9 @@
         <param name="myKey" type="Boolean" mandatory="false">
             <description>Information related to the MyKey feature</description>
         </param>
+        <param name="windowStatus" type="Boolean" mandatory="false" since="6.2">
+            <description>See WindowStatus</description>
+        </param>
     </function>
     
     <function name="SubscribeVehicleData" functionID="SubscribeVehicleDataID" messagetype="response" since="2.0">
@@ -6020,6 +6039,9 @@
         <param name="myKey" type="VehicleDataResult" mandatory="false">
             <description>Information related to the MyKey feature</description>
         </param>
+        <param name="windowStatus" type="VehicleDataResult" mandatory="false" since="6.2">
+            <description>See WindowStatus</description>
+        </param>
     </function>
     
     <function name="UnsubscribeVehicleData" functionID="UnsubscribeVehicleDataID" messagetype="request" since="2.0">
@@ -6111,6 +6133,9 @@
         </param>
         <param name="myKey" type="Boolean" mandatory="false">
             <description>Information related to the MyKey feature</description>
+        </param>
+        <param name="windowStatus" type="Boolean" mandatory="false" since="6.2">
+            <description>See WindowStatus</description>
         </param>
     </function>
     
@@ -6224,6 +6249,9 @@
         <param name="myKey" type="VehicleDataResult" mandatory="false">
             <description>Information related to the MyKey feature</description>
         </param>
+        <param name="windowStatus" type="VehicleDataResult" mandatory="false" since="6.2">
+            <description>See WindowStatus</description>
+        </param>
     </function>
     
     <function name="GetVehicleData" functionID="GetVehicleDataID" messagetype="request" since="2.0">
@@ -6318,6 +6346,9 @@
         </param>
         <param name="myKey" type="Boolean" mandatory="false">
             <description>Information related to the MyKey feature</description>
+        </param>
+        <param name="windowStatus" type="Boolean" mandatory="false" since="6.2">
+            <description>See WindowStatus</description>
         </param>
     </function>
     
@@ -6434,6 +6465,9 @@
         </param>
         <param name="myKey" type="MyKey" mandatory="false">
             <description>Information related to the MyKey feature</description>
+        </param>
+        <param name="windowStatus" type="WindowStatus" array="true" minsize="0" maxsize="100" mandatory="false">
+            <description>See WindowStatus</description>
         </param>
     </function>
     
@@ -8132,6 +8166,9 @@
         </param>
         <param name="myKey" type="MyKey" mandatory="false">
             <description>Information related to the MyKey feature</description>
+        </param>
+        <param name="windowStatus" type="WindowStatus" array="true" minsize="0" maxsize="100" mandatory="false">
+            <description>See WindowStatus</description>
         </param>
     </function>
     

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmartDeviceLink
 # RPC Spec
 
-###### Version: 6.2.0
+###### Version: 6.0.0
 
 ## Enumerations
 
@@ -3943,7 +3943,7 @@ Message Type: **response**
 |`emergencyEvent`|VehicleDataResult|False|Information related to an emergency event (and if it occurred)|
 |`clusterModes`|VehicleDataResult|False|The status modes of the cluster|
 |`myKey`|VehicleDataResult|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|VehicleDataResult|False|Information related to subscribe VD response|
 
 
 ### GetVehicleData
@@ -4028,7 +4028,7 @@ Message Type: **response**
 |`emergencyEvent`|EmergencyEvent|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|ClusterModeStatus|False|The status modes of the cluster|
 |`myKey`|MyKey|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|WindowStatus|False|Information related to window status|
 
 
 ### ReadDID
@@ -5116,7 +5116,7 @@ Callback for the periodic and non periodic vehicle data read function.
 |`emergencyEvent`|EmergencyEvent|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|ClusterModeStatus|False|The status modes of the cluster|
 |`myKey`|MyKey|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|WindowStatus|False|Information related to window status|
 
 
 ### OnCommand

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmartDeviceLink
 # RPC Spec
 
-###### Version: 6.0.0
+###### Version: 6.2.0
 
 ## Enumerations
 
@@ -411,6 +411,7 @@ Defines the data types that can be published and subscribed to.
 |`VEHICLEDATA_ELECTRONICPARKBRAKESTATUS`||
 |`VEHICLEDATA_CLOUDAPPVEHICLEID`||
 |`VEHICLEDATA_OEM_CUSTOM_DATA`||
+|`VEHICLEDATA_WINDOWSTATUS`||
 
 
 ### HybridAppPreference
@@ -1832,6 +1833,21 @@ Specifies the version number of the SmartDeviceLink protocol that is supported b
 |`type`|FuelType|False||
 |`range`|Float|False|The estimate range in KM the vehicle can travel based on fuel level and consumption.            |
 
+### WindowState
+##### Parameters
+
+| Value |  Type | Mandatory | Description | 
+| ---------- | ---------- |:-----------: |:-----------:|
+|`approximatePosition`|Integer|True|The approximate percentage that the window is open - 0 being fully closed, 100 being fully open|
+|`deviation`|Integer|True|The percentage deviation of the approximatePosition. e.g. If the approximatePosition is 50 and the deviation is 10, then the window's location is somewhere between 40 and 60.|
+
+### WindowStatus
+##### Parameters
+
+| Value |  Type | Mandatory | Description | 
+| ---------- | ---------- |:-----------: |:-----------:|
+|`location`|Grid|True||
+|`state`|WindowState|True||
 
 ### SingleTireStatus
 ##### Parameters
@@ -3803,6 +3819,7 @@ Subscribes for specific published data items.
 |`emergencyEvent`|Boolean|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|Boolean|False|The status modes of the cluster|
 |`myKey`|Boolean|False|Information related to the MyKey feature|
+|`windowStatus`|Boolean|False|Information related to window status|
 
 
 ### SubscribeVehicleData
@@ -3844,7 +3861,7 @@ Message Type: **response**
 |`emergencyEvent`|VehicleDataResult|False|Information related to an emergency event (and if it occurred)|
 |`clusterModes`|VehicleDataResult|False|The status modes of the cluster|
 |`myKey`|VehicleDataResult|False|Information related to the MyKey feature|
-
+|`windowStatus`|Boolean|False|Information related to window status|
 
 ### UnsubscribeVehicleData
 Message Type: **request**
@@ -3884,6 +3901,7 @@ This function is used to unsubscribe the notifications from the subscribeVehicle
 |`emergencyEvent`|Boolean|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|Boolean|False|The status modes of the cluster|
 |`myKey`|Boolean|False|Information related to the MyKey feature|
+|`windowStatus`|Boolean|False|Information related to window status|
 
 
 ### UnsubscribeVehicleData
@@ -3925,6 +3943,7 @@ Message Type: **response**
 |`emergencyEvent`|VehicleDataResult|False|Information related to an emergency event (and if it occurred)|
 |`clusterModes`|VehicleDataResult|False|The status modes of the cluster|
 |`myKey`|VehicleDataResult|False|Information related to the MyKey feature|
+|`windowStatus`|Boolean|False|Information related to window status|
 
 
 ### GetVehicleData
@@ -3966,6 +3985,7 @@ Non periodic vehicle data read request.
 |`emergencyEvent`|Boolean|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|Boolean|False|The status modes of the cluster|
 |`myKey`|Boolean|False|Information related to the MyKey feature|
+|`windowStatus`|Boolean|False|Information related to window status|
 
 
 ### GetVehicleData
@@ -4008,6 +4028,7 @@ Message Type: **response**
 |`emergencyEvent`|EmergencyEvent|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|ClusterModeStatus|False|The status modes of the cluster|
 |`myKey`|MyKey|False|Information related to the MyKey feature|
+|`windowStatus`|Boolean|False|Information related to window status|
 
 
 ### ReadDID
@@ -5095,6 +5116,7 @@ Callback for the periodic and non periodic vehicle data read function.
 |`emergencyEvent`|EmergencyEvent|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|ClusterModeStatus|False|The status modes of the cluster|
 |`myKey`|MyKey|False|Information related to the MyKey feature|
+|`windowStatus`|Boolean|False|Information related to window status|
 
 
 ### OnCommand

--- a/README.md
+++ b/README.md
@@ -1830,21 +1830,6 @@ Specifies the version number of the SmartDeviceLink protocol that is supported b
 |`type`|FuelType|False||
 |`range`|Float|False|The estimate range in KM the vehicle can travel based on fuel level and consumption.|
 
-### WindowState
-##### Parameters
-
-| Value |  Type | Mandatory | Description | 
-| ---------- | ---------- |:-----------: |:-----------:|
-|`approximatePosition`|Integer|True|The approximate percentage that the window is open - 0 being fully closed, 100 being fully open|
-|`deviation`|Integer|True|The percentage deviation of the approximatePosition. e.g. If the approximatePosition is 50 and the deviation is 10, then the window's location is somewhere between 40 and 60.|
-
-### WindowStatus
-##### Parameters
-
-| Value |  Type | Mandatory | Description | 
-| ---------- | ---------- |:-----------: |:-----------:|
-|`location`|Grid|True||
-|`state`|WindowState|True||
 
 ### SingleTireStatus
 ##### Parameters
@@ -2196,6 +2181,26 @@ Describes a location (origin coordinates and span) of a vehicle component.
 |`colspan`|Integer|False||
 |`rowspan`|Integer|False||
 |`levelspan`|Integer|False||
+
+
+### WindowState
+##### Parameters
+
+| Value |  Type | Mandatory | Description | 
+| ---------- | ---------- |:-----------: |:-----------:|
+|`approximatePosition`|Integer|True|The approximate percentage that the window is open - 0 being fully closed, 100 being fully open|
+|`deviation`|Integer|True|The percentage deviation of the approximatePosition. e.g. If the approximatePosition is 50 and the deviation is 10, then the window's location is somewhere between 40 and 60.|
+
+
+### WindowStatus
+Describes the status of a window of a door/liftgate etc.
+
+##### Parameters
+
+| Value |  Type | Mandatory | Description | 
+| ---------- | ---------- |:-----------: |:-----------:|
+|`location`|Grid|True||
+|`state`|WindowState|True||
 
 
 ### ModuleInfo
@@ -3789,7 +3794,7 @@ Subscribes for specific published data items. The data will be only sent if it h
 |`emergencyEvent`|Boolean|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|Boolean|False|The status modes of the cluster|
 |`myKey`|Boolean|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|Boolean|False|See WindowStatus|
 
 
 ### SubscribeVehicleData
@@ -3831,7 +3836,8 @@ Message Type: **response**
 |`emergencyEvent`|VehicleDataResult|False|Information related to an emergency event (and if it occurred)|
 |`clusterModes`|VehicleDataResult|False|The status modes of the cluster|
 |`myKey`|VehicleDataResult|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|VehicleDataResult|False|See WindowStatus|
+
 
 ### UnsubscribeVehicleData
 Message Type: **request**
@@ -3871,7 +3877,7 @@ This function is used to unsubscribe the notifications from the subscribeVehicle
 |`emergencyEvent`|Boolean|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|Boolean|False|The status modes of the cluster|
 |`myKey`|Boolean|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|Boolean|False|See WindowStatus|
 
 
 ### UnsubscribeVehicleData
@@ -3913,7 +3919,7 @@ Message Type: **response**
 |`emergencyEvent`|VehicleDataResult|False|Information related to an emergency event (and if it occurred)|
 |`clusterModes`|VehicleDataResult|False|The status modes of the cluster|
 |`myKey`|VehicleDataResult|False|Information related to the MyKey feature|
-|`windowStatus`|VehicleDataResult|False|Information related to subscribe VD response|
+|`windowStatus`|VehicleDataResult|False|See WindowStatus|
 
 
 ### GetVehicleData
@@ -3955,7 +3961,7 @@ Non periodic vehicle data read request.
 |`emergencyEvent`|Boolean|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|Boolean|False|The status modes of the cluster|
 |`myKey`|Boolean|False|Information related to the MyKey feature|
-|`windowStatus`|Boolean|False|Information related to window status|
+|`windowStatus`|Boolean|False|See WindowStatus|
 
 
 ### GetVehicleData
@@ -3998,7 +4004,7 @@ Message Type: **response**
 |`emergencyEvent`|EmergencyEvent|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|ClusterModeStatus|False|The status modes of the cluster|
 |`myKey`|MyKey|False|Information related to the MyKey feature|
-|`windowStatus`|WindowStatus|False|Information related to window status|
+|`windowStatus`|WindowStatus[]|False|See WindowStatus|
 
 
 ### ReadDID
@@ -5045,7 +5051,7 @@ Callback for the periodic and non periodic vehicle data read function.
 |`emergencyEvent`|EmergencyEvent|False|Information related to an emergency event (and if it occurred)|
 |`clusterModeStatus`|ClusterModeStatus|False|The status modes of the cluster|
 |`myKey`|MyKey|False|Information related to the MyKey feature|
-|`windowStatus`|WindowStatus|False|Information related to window status|
+|`windowStatus`|WindowStatus[]|False|See WindowStatus|
 
 
 ### OnCommand


### PR DESCRIPTION
Implements [#3193](https://github.com/smartdevicelink/sdl_core/issues/3193)

Summary:
Current PR adds new vehicle data `WindowStatus` and `WindowState` type into `MOBILE_API.xml`.
Also next RPCs updated: Subscribe,Unsubscribe/Get/OnVehicleData.