### PR TITLE
Driver Distraction Capability & Additional Submenu Depth

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -5059,7 +5059,7 @@
         <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false" since="7.0">
             <description>
                 unique ID of the sub menu, the command will be added to.
-                If not provided, it will be provided to the top level of the in application menu.
+                If not provided or 0, it will be provided to the top level of the in application menu.
             </description>
         </param>
     </function>

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -3026,6 +3026,7 @@
         <element name="APP_SERVICES" since="5.1"/>
         <element name="SEAT_LOCATION" since="6.0"/>
         <element name="DISPLAYS" since="6.0"/>
+        <element name="DRIVER_DISTRACTION" since="6.2"/>
     </enum>
     
     <struct name="NavigationCapability" since="4.5">
@@ -3077,6 +3078,15 @@
         </param>
         <param name="scale" type="Float" minvalue="1" maxvalue="10" mandatory="false" since="6.0">
             <description>The scaling factor the app should use to change the size of the projecting view.</description>
+        </param>
+    </struct>
+
+    <struct name="DriverDistractionCapability" since="6.2">
+        <param name="menuLength" type="Integer" mandatory="false">
+            <description>The number of items allowed in a Choice Set or Command menu while the driver is distracted</description>
+        </param>
+        <param name="subMenuDepth" type="Integer" minvalue="1" mandatory="false">
+            <description>The depth of submenus allowed when the driver is distracted. e.g. 3 == top level menu -> submenu -> submenu; 1 == top level menu only</description>
         </param>
     </struct>
 
@@ -4435,6 +4445,9 @@
             <description>Contains information about the locations of each seat</description>
         </param>
         <param name="displayCapabilities" type="DisplayCapability" array="true" minsize="1" maxsize="1000" mandatory="false" since="6.0"/>
+        <param name="driverDistractionCapability" type="DriverDistractionCapability" mandatory="false" since="6.2">
+            <description>Describes capabilities when the driver is distracted</description>
+        </param>
     </struct>
 
     <!-- Requests/Responses -->
@@ -5038,6 +5051,13 @@
 
         <param name="menuLayout" type="MenuLayout" mandatory="false" since="6.0">
             <description>Sets the layout of the submenu screen.</description>
+        </param>
+
+        <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false" since="6.2">
+            <description>
+                unique ID of the sub menu, the command will be added to.
+                If not provided, it will be provided to the top level of the in application menu.
+            </description>
         </param>
     </function>
     

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/xml" href="protocol2html.xsl"?>
 
-<interface name="SmartDeviceLink RAPI" version="6.0.0" minVersion="1.0" date="2019-03-19">
+<interface name="SmartDeviceLink RAPI" version="6.1.0" minVersion="1.0" date="2019-03-19">
     <enum name="Result" internal_scope="base" since="1.0">
         <element name="SUCCESS">
             <description>The request succeeded</description>
@@ -3026,7 +3026,7 @@
         <element name="APP_SERVICES" since="5.1"/>
         <element name="SEAT_LOCATION" since="6.0"/>
         <element name="DISPLAYS" since="6.0"/>
-        <element name="DRIVER_DISTRACTION" since="6.2"/>
+        <element name="DRIVER_DISTRACTION" since="6.1"/>
     </enum>
     
     <struct name="NavigationCapability" since="4.5">
@@ -3081,7 +3081,7 @@
         </param>
     </struct>
 
-    <struct name="DriverDistractionCapability" since="6.2">
+    <struct name="DriverDistractionCapability" since="6.1">
         <param name="menuLength" type="Integer" mandatory="false">
             <description>The number of items allowed in a Choice Set or Command menu while the driver is distracted</description>
         </param>
@@ -4445,7 +4445,7 @@
             <description>Contains information about the locations of each seat</description>
         </param>
         <param name="displayCapabilities" type="DisplayCapability" array="true" minsize="1" maxsize="1000" mandatory="false" since="6.0"/>
-        <param name="driverDistractionCapability" type="DriverDistractionCapability" mandatory="false" since="6.2">
+        <param name="driverDistractionCapability" type="DriverDistractionCapability" mandatory="false" since="6.1">
             <description>Describes capabilities when the driver is distracted</description>
         </param>
     </struct>
@@ -5053,7 +5053,7 @@
             <description>Sets the layout of the submenu screen.</description>
         </param>
 
-        <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false" since="6.2">
+        <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false" since="6.1">
             <description>
                 unique ID of the sub menu, the command will be added to.
                 If not provided, it will be provided to the top level of the in application menu.

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/xml" href="protocol2html.xsl"?>
 
-<interface name="SmartDeviceLink RAPI" version="6.1.0" minVersion="1.0" date="2019-03-19">
+<interface name="SmartDeviceLink RAPI" version="7.0.0" minVersion="1.0" date="2019-03-19">
     <enum name="Result" internal_scope="base" since="1.0">
         <element name="SUCCESS">
             <description>The request succeeded</description>
@@ -3026,7 +3026,7 @@
         <element name="APP_SERVICES" since="5.1"/>
         <element name="SEAT_LOCATION" since="6.0"/>
         <element name="DISPLAYS" since="6.0"/>
-        <element name="DRIVER_DISTRACTION" since="6.1"/>
+        <element name="DRIVER_DISTRACTION" since="7.0"/>
     </enum>
     
     <struct name="NavigationCapability" since="4.5">
@@ -3081,7 +3081,7 @@
         </param>
     </struct>
 
-    <struct name="DriverDistractionCapability" since="6.1">
+    <struct name="DriverDistractionCapability" since="7.0">
         <param name="menuLength" type="Integer" mandatory="false">
             <description>The number of items allowed in a Choice Set or Command menu while the driver is distracted</description>
         </param>
@@ -4445,7 +4445,7 @@
             <description>Contains information about the locations of each seat</description>
         </param>
         <param name="displayCapabilities" type="DisplayCapability" array="true" minsize="1" maxsize="1000" mandatory="false" since="6.0"/>
-        <param name="driverDistractionCapability" type="DriverDistractionCapability" mandatory="false" since="6.1">
+        <param name="driverDistractionCapability" type="DriverDistractionCapability" mandatory="false" since="7.0">
             <description>Describes capabilities when the driver is distracted</description>
         </param>
     </struct>
@@ -5053,7 +5053,7 @@
             <description>Sets the layout of the submenu screen.</description>
         </param>
 
-        <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false" since="6.1">
+        <param name="parentID" type="Integer" minvalue="0" maxvalue="2000000000" defvalue="0" mandatory="false" since="7.0">
             <description>
                 unique ID of the sub menu, the command will be added to.
                 If not provided, it will be provided to the top level of the in application menu.

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -2460,6 +2460,9 @@
         <param name="seatLocation" type="Boolean" mandatory="false" since="6.0">
             <description>Availability of seat location feature. True: Available, False: Not Available</description>
         </param>
+        <param name="driverDistraction" type="Boolean" mandatory="false" since="7.0">
+            <description>Availability of driver distraction capability. True: Available, False: Not Available</description>
+        </param>
     </struct>
 
     <struct name="MenuParams" since="1.0">


### PR DESCRIPTION
The implementations of proposals [0148-template-additional-submenus](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0148-template-additional-submenus.md) and [0152-driver-distraction-list-limits](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0152-driver-distraction-list-limits.md) are co-dependent and need to be implemented together.

Fixes #70 & #72 