### PR TITLE
RPC spec module generator should not add a patch version.

### DIFF
--- a/InterfaceParser/parsers/rpc_base.py
+++ b/InterfaceParser/parsers/rpc_base.py
@@ -733,8 +733,6 @@ class RPCBase(ABC):
                              "Need format of major_version.minor_version or major_version.minor_version.patch_version")
 
         version_array = version.split(".")
-        if len(version_array) == 2:
-            version_array.append("0")
         dot_str = "."
         return dot_str.join(version_array)
 


### PR DESCRIPTION
Fixed RPC spec generator to stop adding the patch version to the generated files.
The changes are made on rpc_base.py.

Related to issue: smartdevicelink/sdl_ios#1752