### PR TITLE
add info about currentTemperature in the case of forecasts

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4317,7 +4317,7 @@
 
     <struct name="WeatherData" since="5.1">
         <param name="currentTemperature" type="Temperature" mandatory="false">
-            <description>This parameter may be populated with a forecasted temperature even when the high and low parameters are not available.</description>
+            <description>This parameter could be the present temperature, the temperature of a future minute, the temperature of a future hour, or an average temperature of a future day</description>
         </param>
         <param name="temperatureHigh" type="Temperature" mandatory="false"/>
         <param name="temperatureLow" type="Temperature" mandatory="false"/>

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4316,7 +4316,9 @@
     </struct>
 
     <struct name="WeatherData" since="5.1">
-        <param name="currentTemperature" type="Temperature" mandatory="false"/>
+        <param name="currentTemperature" type="Temperature" mandatory="false">
+            <description>This parameter may be populated with a forecasted temperature even when the high and low parameters are not available.</description>
+        </param>
         <param name="temperatureHigh" type="Temperature" mandatory="false"/>
         <param name="temperatureLow" type="Temperature" mandatory="false"/>
         <param name="apparentTemperature" type="Temperature" mandatory="false"/>

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4317,7 +4317,7 @@
 
     <struct name="WeatherData" since="5.1">
         <param name="currentTemperature" type="Temperature" mandatory="false">
-            <description>This parameter could be the present temperature, the temperature of a future minute, the temperature of a future hour, or an average temperature of a future day</description>
+            <description>The central temperature depending on the context of the weather data. It could be the present temperature, the temperature of a future minute, the temperature of a future hour, or an average temperature of a future day, for example.</description>
         </param>
         <param name="temperatureHigh" type="Temperature" mandatory="false"/>
         <param name="temperatureLow" type="Temperature" mandatory="false"/>

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ For touchscreen interactions, the mode of how the choices are presented.
 
 
 ### PredefinedWindows
+Specifies IDs for windows which are predefined and pre-created. The mobile libraries and SDL Core use the integer value when referencing these elements.
+
 ##### Elements
 
 | Value | Description | 
@@ -1503,7 +1505,7 @@ Enumeration linking function names with function IDs in SmartDeviceLink protocol
 
 
 ### messageType
-Enumeration linking message types with function types in WiPro protocol. Assumes enumeration starts at value 0.
+Enumeration linking message types with function types in WiPro protocol. Assumes enumeration starts at value 0. The integer value is used in the protocol binary header.
 
 ##### Elements
 
@@ -1602,6 +1604,8 @@ List possible seats that is a remote controllable seat.
 
 
 ### LightName
+Enumeration that describes possible values of light name. The mobile libraries and SDL Core use the name string when referencing these elements.
+
 ##### Elements
 
 | Value | Description | 
@@ -3052,7 +3056,7 @@ This data is related to what a media service should provide
 
 | Value |  Type | Mandatory | Description | 
 | ---------- | ---------- |:-----------: |:-----------:|
-|`currentTemperature`|Temperature|False||
+|`currentTemperature`|Temperature|False|This parameter may be populated with a forecasted temperature even when the high and low parameters are not available.|
 |`temperatureHigh`|Temperature|False||
 |`temperatureLow`|Temperature|False||
 |`apparentTemperature`|Temperature|False||

--- a/README.md
+++ b/README.md
@@ -3056,7 +3056,7 @@ This data is related to what a media service should provide
 
 | Value |  Type | Mandatory | Description | 
 | ---------- | ---------- |:-----------: |:-----------:|
-|`currentTemperature`|Temperature|False|This parameter may be populated with a forecasted temperature even when the high and low parameters are not available.|
+|`currentTemperature`|Temperature|False|The central temperature depending on the context of the weather data. It could be the present temperature, the temperature of a future minute, the temperature of a future hour, or an average temperature of a future day, for example.|
 |`temperatureHigh`|Temperature|False||
 |`temperatureLow`|Temperature|False||
 |`apparentTemperature`|Temperature|False||


### PR DESCRIPTION
Fixes #208 

Includes markdown changes from https://github.com/smartdevicelink/rpc_spec/pull/236, generator wasn't run.


Some forecasts such as minutely/hourly etc. from some weather data APIs do not provide a predicted high/low temperature but may still have a predicted temperature overall in the currentTemperature property.