### PR TITLE
remove xmlschema element getchildren

### DIFF
--- a/InterfaceParser/parsers/rpc_base.py
+++ b/InterfaceParser/parsers/rpc_base.py
@@ -626,7 +626,7 @@ class RPCBase(ABC):
         if len(subelement.attrib) != 1:
             raise ParseError("Unexpected attributes for element '{}' of parameter '{}'"
                              .format(element_name, params["name"]))
-        children = subelement.getchildren()
+        children = list(subelement)
         for child in children:
             if child.tag == "description":
                 children.remove(child)


### PR DESCRIPTION
fixes https://github.com/smartdevicelink/rpc_spec/issues/307

this method was removed in python 3.9, i have replaced it with list iteration which was added in python 3.2