### PR TITLE
Fix/changes overwritten by commit 0110478

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -7287,16 +7287,10 @@
         <param name="nextTurnIcon" type="Image" mandatory="false" since="3.0">
         </param>
         <param name="distanceToManeuver" type="Float" minvalue="0" maxvalue="1000000000" mandatory="false" since="2.0">
-            <description>
-                Fraction of distance till next maneuver (starting from when AlertManeuver is triggered).
-                Used to calculate progress bar.
-            </description>
+            <description>Distance (in meters) until next maneuver. May be used to calculate progress bar.</description>
         </param>
         <param name="distanceToManeuverScale" type="Float" minvalue="0" maxvalue="1000000000" mandatory="false" since="2.0">
-            <description>
-                Distance till next maneuver (starting from) from previous maneuver.
-                Used to calculate progress bar.
-            </description>
+            <description>Distance (in meters) from previous maneuver to next maneuver. May be used to calculate progress bar.</description>
         </param>
         <param name="maneuverComplete" type="Boolean" mandatory="false" since="2.0">
             <description>
@@ -8937,7 +8931,10 @@
     <!-- Ford Specific APIs -->
     <!-- ~~~~~~~~~~~~~~~~~~ -->
     
-    <function name="EncodedSyncPData" functionID="EncodedSyncPDataID" messagetype="request" since="1.0">
+    <function name="EncodedSyncPData" functionID="EncodedSyncPDataID" messagetype="request" deprecated="true" since="7.1">
+        <history>	
+            <function name="EncodedSyncPData" functionID="EncodedSyncPDataID" messagetype="request" since="1.0" until="7.1"/>	
+        </history>
         <description>
             Allows encoded data in the form of SyncP packets to be sent to the SYNC module.
             Legacy / v1 Protocol implementation; use SyncPData instead.
@@ -8950,7 +8947,10 @@
         </param>
     </function>
     
-    <function name="EncodedSyncPData" functionID="EncodedSyncPDataID" messagetype="response" since="1.0">
+    <function name="EncodedSyncPData" functionID="EncodedSyncPDataID" messagetype="response" deprecated="true" since="7.1">
+        <history>	
+            <function name="EncodedSyncPData" functionID="EncodedSyncPDataID" messagetype="response" since="1.0" until="7.1"/>	
+        </history>
         <param name="success" type="Boolean" platform="documentation" mandatory="true">
             <description> true, if successful; false, if failed </description>
         </param>
@@ -9001,7 +9001,10 @@
      </function>
      -->
     
-    <function name="OnEncodedSyncPData" functionID="OnEncodedSyncPDataID" messagetype="notification" since="1.0">
+    <function name="OnEncodedSyncPData" functionID="OnEncodedSyncPDataID" messagetype="notification" deprecated="true" since="7.1">
+        <history>	
+            <function name="OnEncodedSyncPData" functionID="OnEncodedSyncPDataID" messagetype="notification" since="1.0" until="7.1"/>	
+        </history>
         <description>
             Callback including encoded data of any SyncP packets that SYNC needs to send back to the mobile device.
             Legacy / v1 Protocol implementation; responds to EncodedSyncPData.

--- a/README.md
+++ b/README.md
@@ -1795,6 +1795,15 @@ Enumeration that describes possible values of light name. The mobile libraries a
 |`MANIFEST_UPDATE`|The service has updated its manifest. This could imply updated capabilities|
 
 
+### SeekIndicatorType
+##### Elements
+
+| Value | Description | 
+| ---------- |:-----------:|
+|`TRACK`||
+|`TIME`||
+
+
 
 <div style="page-break-after: always;"></div>
 
@@ -3279,6 +3288,17 @@ The systemCapabilityType identifies which data object exists in this struct. For
 |`transmissionType`|TransmissionType|False|Tells the transmission type|
 
 
+### SeekStreamingIndicator
+The seek next / skip previous subscription buttons' content
+
+##### Parameters
+
+| Value |  Type | Mandatory | Description | 
+| ---------- | ---------- |:-----------: |:-----------:|
+|`type`|SeekIndicatorType|True||
+|`seekTime`|Integer|False|If the type is TIME, this number of seconds may be present alongside the skip indicator. It will indicate the number of seconds that the currently playing media will skip forward or backward.|
+
+
 
 <div style="page-break-after: always;"></div>
 
@@ -3831,7 +3851,7 @@ Sets the initial media clock value and automatic update method.
 |`updateMode`|UpdateMode|True|Enumeration to control the media clock. In case of pause, resume, or clear, the start time value is ignored and shall be left out. For resume, the time continues with the same value as it was when paused.|
 |`audioStreamingIndicator`|AudioStreamingIndicator|False|Enumeration for the indicator icon on a play/pause button. see AudioStreamingIndicator.|
 |`forwardSeekIndicator`|SeekStreamingIndicator|False|Used to control the forward seek button to either skip forward a set amount of time or to the next track.|
-|`backSeekIndicator`|SeekStreamingIndicator|False|Used to control the forward seek button to either skip back a set amount of time or to the previous track.|
+|`backSeekIndicator`|SeekStreamingIndicator|False|Used to control the back seek button to either skip back a set amount of time or to the previous track.|
 |`countRate`|Float|False|The value of this parameter is the amount that the media clock timer will advance per 1.0 seconds of real time. Values less than 1.0 will therefore advance the timer slower than real-time, while values greater than 1.0 will advance the timer faster than real-time. e.g. If this parameter is set to `0.5`, the timer will advance one second per two seconds real-time, or at 50% speed. If this parameter is set to `2.0`, the timer will advance two seconds per one second real-time, or at 200% speed.|
 
 


### PR DESCRIPTION
https://github.com/smartdevicelink/rpc_spec/commit/0110478f9c7ab7f87d526ef194dfa7ef156d2c57 seems to have overwritten the changes to the MOBILE_API made in https://github.com/smartdevicelink/rpc_spec/pull/304 and https://github.com/smartdevicelink/rpc_spec/pull/310