### PR TITLE
[SDL 0293] Enable OEM exclusive apps support

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -4961,9 +4961,12 @@
             <description>See AudioPassThruCapability</description>
         </param>
         
-        <param name="vehicleType" type="VehicleType" mandatory="false" since="2.0">
-            <description>Specifies the vehicle's type. See VehicleType.</description>
-        </param>
+        <param name="vehicleType" type="VehicleType" mandatory="false" since="7.1" deprecated="true">
+        	<description>Specifies the vehicle's type. See VehicleType.</description>
+        	<history>
+            <param name="vehicleType" type="VehicleType" mandatory="false" since="2.0" until="7.1" />
+        	</history>
+    	</param>
         
         <param name="supportedDiagModes" type="Integer" minvalue="0" maxvalue="255" array="true" minsize="1" maxsize="100" mandatory="false" since="3.0">
             <description>
@@ -4980,9 +4983,12 @@
             <description>The SmartDeviceLink version.</description>
         </param>
         
-        <param name="systemSoftwareVersion" type="String" maxlength="100" mandatory="false" platform="documentation" since="3.0">
-            <description>The software version of the system that implements the SmartDeviceLink core.</description>
-        </param>
+        <param name="systemSoftwareVersion" type="String" maxlength="100" mandatory="false" platform="documentation" since="7.1" deprecated="true">
+        	<description>The software version of the system that implements the SmartDeviceLink core.</description>
+        	<history>
+            <param name="systemSoftwareVersion" type="String" maxlength="100" mandatory="false" platform="documentation" since="3.0" until="7.1" />
+        	</history>
+    	</param>
 
         <param name="iconResumed" type="Boolean" mandatory="false" since="5.0">
             <description>


### PR DESCRIPTION
Implements https://github.com/smartdevicelink/rpc_spec/issues/305

#### Summary 
Deprecate the VehicleType and systemSoftwareVersion params as to not cause confusion with the newly added params to the StartServiceACK for the RPC service.