### PR TITLE
add language option EN-IE

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -285,6 +285,9 @@
         <element name="HI-IN" internal_name="HI_IN" since="4.5">
             <description>Hindi - India</description>
         </element>
+        <element name="EN-IE" internal_name="EN-IE" since="8.0">
+            <description>English - Ireland</description>
+        </element>
     </enum>
     
     <enum name="UpdateMode" since="1.0">

--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -285,7 +285,7 @@
         <element name="HI-IN" internal_name="HI_IN" since="4.5">
             <description>Hindi - India</description>
         </element>
-        <element name="EN-IE" internal_name="EN-IE" since="8.0">
+        <element name="EN-IE" internal_name="EN_IE" since="8.0">
             <description>English - Ireland</description>
         </element>
     </enum>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmartDeviceLink
 # RPC Spec
 
-###### Version: 7.1.0
+###### Version: 8.0.0
 
 ## Enumerations
 
@@ -111,6 +111,7 @@
 |`VI-VN`|Vietnamese - Vietnam|
 |`MS-MY`|Malay - Malaysia|
 |`HI-IN`|Hindi - India|
+|`EN-IE`|English - Ireland|
 
 
 ### UpdateMode


### PR DESCRIPTION
Partially fixes https://github.com/smartdevicelink/sdl_core/issues/1942

Add valid language option that Core already uses in preloaded_pt: `EN-IE`